### PR TITLE
Update CORS origins

### DIFF
--- a/Libroteka/settings.py
+++ b/Libroteka/settings.py
@@ -74,6 +74,8 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:4200",
     "https://libroteka-frontend.onrender.com",
     "https://libroback.koyeb.app",
+    "https://libroteka-frontend-prod.onrender.com",
+    "https://libroteka-frontend-dev.onrender.com"
 ]
 
 CORS_ALLOW_METHODS = [


### PR DESCRIPTION
Added `"https://libroteka-frontend-prod.onrender.com"` and `"https://libroteka-frontend-dev.onrender.com"` to the list of allowed origins in the CORS configuration.